### PR TITLE
v4sil gcc compiler fix

### DIFF
--- a/fastapprox/src/fastonebigheader.h
+++ b/fastapprox/src/fastonebigheader.h
@@ -106,7 +106,7 @@ typedef __m128i v4si;
 
 #define v4sfl(x) ((const v4sf) { (x), (x), (x), (x) })
 #define v2dil(x) ((const v4si) { (x), (x) })
-#define v4sil(x) v2dil((((unsigned long long) (x)) << 32) | (x))
+#define v4sil(x) v2dil((((long) (x)) << 32) | (long) (x))
 
 typedef union { v4sf f; float array[4]; } v4sfindexer;
 #define v4sf_index(_findx, _findi)      \


### PR DESCRIPTION
The previous definition of v4sil was trying to cast to a 128bit type, but only filling it with 64bits of data.

Under c++11, this fails to compile with a narrowing warning.

By casting to a long above, we match the 64bit width of the underlying __m64 type, and also the v2dil cast then work correctly to widen the 2 64bit inputs to the expected final 128bit width.

This fixes compiler warnings on gcc using -Wc++11-narrowing.